### PR TITLE
[CHORE](ci) Auto-pin versions in README examples + enforce zizmor compliance 🌈 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           PACKAGE_SIZE: ${{ matrix.package-size }}
         run: |
-          cd test/$PACKAGE_SIZE-package
+          cd "test/$PACKAGE_SIZE-package"
           npm install
 
   benchmark:
@@ -56,11 +56,11 @@ jobs:
         env:
           PACKAGE_SIZE: ${{ matrix.package-size }}
         run: |
-          cd test/$PACKAGE_SIZE-package
+          cd "test/$PACKAGE_SIZE-package"
           npm install
       - name: Run baseline benchmarks
         env:
           PACKAGE_SIZE: ${{ matrix.package-size }}
         run: |
-          cd test/$PACKAGE_SIZE-package
+          cd "test/$PACKAGE_SIZE-package"
           hyperfine --warmup 2 --runs 10 "npm install" "npm install --audit=false --fund=false --loglevel=error --prefer-offline=true --update-notifier=false --progress=false"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   full-install:
+    name: Full install
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
@@ -29,11 +30,14 @@ jobs:
       - uses: ./
         if: ${{ matrix.sustainable-npm }}
       - name: Install dependencies
+        env:
+          PACKAGE_SIZE: ${{ matrix.package-size }}
         run: |
-          cd test/${{ matrix.package-size }}-package
+          cd test/$PACKAGE_SIZE-package
           npm install
 
   benchmark:
+    name: Benchmark
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -49,10 +53,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y hyperfine
       - name: Cache dependencies
+        env:
+          PACKAGE_SIZE: ${{ matrix.package-size }}
         run: |
-          cd test/${{ matrix.package-size }}-package
+          cd test/$PACKAGE_SIZE-package
           npm install
       - name: Run baseline benchmarks
+        env:
+          PACKAGE_SIZE: ${{ matrix.package-size }}
         run: |
-          cd test/${{ matrix.package-size }}-package
+          cd test/$PACKAGE_SIZE-package
           hyperfine --warmup 2 --runs 10 "npm install" "npm install --audit=false --fund=false --loglevel=error --prefer-offline=true --update-notifier=false --progress=false"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,3 +39,13 @@ jobs:
         with:
           advanced-security: false
           persona: pedantic
+
+  are-we-good:
+    name: Rollup
+    runs-on: ubuntu-latest
+    needs: [super-linter]
+    if: always()
+    steps:
+      - uses: lowlydba/are-we-good@7efad05442f92a1203940ca8b79dd4fb930e75d4 # v1.0.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,13 +24,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 #v8.6.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_MARKDOWN_PRETTIER: false
-          VALIDATE_YAML_PRETTIER: false
-          VALIDATE_JSON_PRETTIER: false
-
       - name: Update README example pins
         uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,14 +7,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  packages: read
-  pull-requests: write # To allow PR comments from tools that use the GITHUB_TOKEN
-  statuses: write # To report GitHub Actions status checks
+permissions: {}
 
 jobs:
   super-linter:
+    name: Lint
+    permissions:
+      contents: read
+      packages: read # Required for package listing
+      pull-requests: write # To allow PR comments from tools that use the GITHUB_TOKEN
+      statuses: write # To report GitHub Actions status checks
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,3 +30,19 @@ jobs:
           VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_YAML_PRETTIER: false
           VALIDATE_JSON_PRETTIER: false
+
+      - name: Update README example pins
+        uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          skip_push: "true"
+          update: "true"
+          verify: "true"
+          min_age: "7"
+          includes: |
+            README.md
+          separator: "  # "
+
+      - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          persona: pedantic

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
           min_age: "7"
           includes: |
             README.md
-          separator: "  # "
+          separator: " # "
 
       - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,3 +82,13 @@ jobs:
           if [ "$actual_ignore_scripts" != "$expected_ignore_scripts" ]; then echo "Mismatch in ignore-scripts"; exit 1; fi
 
           echo "All npm configurations match the expected values."
+
+  are-we-good:
+    name: Rollup
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - uses: lowlydba/are-we-good@7efad05442f92a1203940ca8b79dd4fb930e75d4 # v1.0.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions: read-all
+permissions: {}
 
 jobs:
   test:
+    name: Test
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ After setting up Node with `actions/setup-node`, add this step:
 jobs:
   test:
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-      - uses: lowlydba/sustainable-npm@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - uses: lowlydba/sustainable-npm@31d51025884f424f58f22e4e6578178bb4e79632 # v3.0.0
 ```
 
 To override any defaults:
 
 ```yaml
-- uses: lowlydba/sustainable-npm@v3
+- uses: lowlydba/sustainable-npm@31d51025884f424f58f22e4e6578178bb4e79632 # v3.0.0
   with:
     audit: 'true'
     fund: 'false'


### PR DESCRIPTION
This pull request updates GitHub Actions workflows and documentation to improve security, reliability, and maintainability. The changes include pinning action versions in the README, refining workflow permissions, improving environment variable usage, and adding rollup jobs for workflow status checks.

**Workflow Security and Permissions:**
* Fix all outstanding issues per Zizmor + add Zizmor to the lint workflow
* Use rollup jobs to dynamically require status checks more cleanly for all lint/test jobs
* Removed SuperLinter - we have whats needed now for linting setup explicitly, and its just too slow for current needs

**Documentation Updates:**
* Updated the `README.md` to pin all GitHub Actions to specific commit SHAs for improved security and reproducibility.