### PR TITLE
[CHORE](ci) Add pinact config; update lint workflow & README

### DIFF
--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -4,4 +4,6 @@ files:
   - pattern: .github/workflows/*.yaml
   - pattern: .github/actions/*/action.yml
   - pattern: .github/actions/*/action.yaml
+  - pattern: action.yml
+  - pattern: action.yaml
   - pattern: README.md

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,7 @@
+version: 3
+files:
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml
+  - pattern: .github/actions/*/action.yml
+  - pattern: .github/actions/*/action.yaml
+  - pattern: README.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,13 +27,9 @@ jobs:
       - name: Update README example pins
         uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
-          skip_push: "true"
           update: "true"
           verify: "true"
           min_age: "7"
-          includes: |
-            README.md
-          separator: " # "
 
       - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Update README example pins
+      - name: Check action pins
         uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
           verify: "true"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   super-linter:
     name: Lint
     permissions:
-      contents: read
+      contents: write # To allow updates from pinact
       packages: read # Required for package listing
       pull-requests: write # To allow PR comments from tools that use the GITHUB_TOKEN
       statuses: write # To report GitHub Actions status checks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   super-linter:
     name: Lint
     permissions:
-      contents: write # To allow updates from pinact
+      contents: read
       packages: read # Required for package listing
       pull-requests: write # To allow PR comments from tools that use the GITHUB_TOKEN
       statuses: write # To report GitHub Actions status checks

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Update README example pins
         uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
-          update: "true"
           verify: "true"
           min_age: "7"
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To override any defaults:
 The npm configuration is only printed when [debug logging][debug-logging] is enabled (`RUNNER_DEBUG == 'true'`).
 
 > [!TIP]
-> SemVer tags (e.g. `v3.0.0`) and superseded major tags (e.g. `v2`) are immutable, enforced via [repository rulesets](https://github.com/lowlydba/sustainable-npm/rules). For maximum supply chain security, [pin to a full commit SHA](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) rather than a tag.
+> SemVer tags (e.g. `v3.0.0`) and superseded major tags (e.g. `v1`, `v2`) are immutable, enforced via [repository rulesets](https://github.com/lowlydba/sustainable-npm/rules). For maximum supply chain security, [pin to a full commit SHA](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) rather than a tag. After v4.0.0, only SemVer tags will be used.
 
 ## Inputs
 


### PR DESCRIPTION
Add .github/pinact.yaml to declare files to be managed by pinact (workflow and action YAMLs, README). Simplify the lint workflow by removing skip_push and the explicit includes/separator for the pinact-action invocation, relying on defaults.